### PR TITLE
Custom labels and assignees feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    issue-db (1.2.0)
+    issue-db (1.3.0)
       faraday-retry (~> 2.2, >= 2.2.1)
       jwt (>= 2.9.3, < 4.0)
       octokit (>= 9.2, < 11.0)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module IssueDB
   module Version
-    VERSION = "1.2.0"
+    VERSION = "1.3.0"
   end
 end


### PR DESCRIPTION
This pull request introduces enhancements to the `issue-db` gem, focusing on improved GitHub issue management through new support for custom labels and assignees. These changes include updates to the documentation, codebase, and versioning to reflect the new functionality.